### PR TITLE
Fix/dictionary

### DIFF
--- a/src/Actor/HumanoidBody.cs
+++ b/src/Actor/HumanoidBody.cs
@@ -37,9 +37,9 @@ public class HumanoidBody : KinematicBody , IBody, IReceiveDamage {
     Foot_r,
     Foot_l
   };
-  System.Collections.Generic.Dictionary<BodyParts, BoneAttachment> boneAttachments;
-  System.Collections.Generic.Dictionary<BodyParts, CollisionShape> collisionShapes;
-  System.Collections.Generic.Dictionary<BodyParts, int> boneIds;
+  Dictionary<BodyParts, BoneAttachment> boneAttachments;
+  Dictionary<BodyParts, CollisionShape> collisionShapes;
+  Dictionary<BodyParts, int> boneIds;
   Vector3 spineRotation;
 
   public bool dead;
@@ -88,9 +88,9 @@ public class HumanoidBody : KinematicBody , IBody, IReceiveDamage {
     AnimationPlayer legsAnimationPlayer = rootNode.FindNode("LegsAnimationPlayer") as AnimationPlayer;
     animHandler = new HumanoidAnimationHandler(armsAnimationPlayer, legsAnimationPlayer);
 
-    boneAttachments = new System.Collections.Generic.Dictionary<BodyParts, BoneAttachment>();
-    collisionShapes = new System.Collections.Generic.Dictionary<BodyParts, CollisionShape>();
-    boneIds = new System.Collections.Generic.Dictionary<BodyParts, int>();
+    boneAttachments = new Dictionary<BodyParts, BoneAttachment>();
+    collisionShapes = new Dictionary<BodyParts, CollisionShape>();
+    boneIds = new Dictionary<BodyParts, int>();
     
     // These commented out bones are turned off for performance reasons.
     CreateBone(BodyParts.Head,        "head",         new Vector3(0.1f, 0.1f, 0.1f), true);

--- a/src/Arena/Arena.cs
+++ b/src/Arena/Arena.cs
@@ -23,16 +23,16 @@ public class Arena : Spatial, IGamemode {
   public List<Actor> enemies;
 
   public int nextId = 1;
-  public System.Collections.Generic.Dictionary<int, int> scores;
-  public System.Collections.Generic.Dictionary<int, Actor> actors;
-  public System.Collections.Generic.Dictionary<int, float> clearQueue;
+  public Dictionary<int, int> scores;
+  public Dictionary<int, Actor> actors;
+  public Dictionary<int, float> clearQueue;
   
   public Arena(){
     PauseMode = PauseModeEnum.Stop;
     enemies = new List<Actor>();
-    actors = new System.Collections.Generic.Dictionary<int, Actor>();
-    scores = new System.Collections.Generic.Dictionary<int, int>();
-    clearQueue = new System.Collections.Generic.Dictionary<int,float>();
+    actors = new Dictionary<int, Actor>();
+    scores = new Dictionary<int, int>();
+    clearQueue = new Dictionary<int,float>();
   }
 
   public void Init(string[] argv){

--- a/src/Career/Encounters/RestSiteEncounter.cs
+++ b/src/Career/Encounters/RestSiteEncounter.cs
@@ -116,8 +116,8 @@ public class RestSiteEncounter : IEncounter {
   }
 
   public static string UpgradeDescription(string upgradeName){
-    System.Collections.Generic.Dictionary<string, string> descriptionMap;
-    descriptionMap = new System.Collections.Generic.Dictionary<string, string>{
+    Dictionary<string, string> descriptionMap;
+    descriptionMap = new Dictionary<string, string>{
       {"Extra endurance","Improved health, take less damage."},
       {"+50 max health", "Take more damage"},
       {"Extra agility", "Run faster"},

--- a/src/Career/PressEvent.cs
+++ b/src/Career/PressEvent.cs
@@ -56,7 +56,7 @@ public class PressEvent {
       return ret;
     }
 
-    public PressEvent(System.Collections.Generic.Dictionary<int, string[]> rows){
+    public PressEvent(Dictionary<int, string[]> rows){
         pressEventNodes = new List<PressEventNode>();
         
         foreach(int key in rows.Keys){

--- a/src/Db/SettingsDb.cs
+++ b/src/Db/SettingsDb.cs
@@ -11,10 +11,10 @@ using System.Collections.Generic;
 public class SettingsDb{
     const string SavesDirectory = "Saves/";
     const string SettingsPath = "Saves/settings.json";
-    System.Collections.Generic.Dictionary<string, string> settings;
+    Dictionary<string, string> settings;
 
     public SettingsDb(){
-        settings = new System.Collections.Generic.Dictionary<string, string>();
+        settings = new Dictionary<string, string>();
         FetchSettings();
     }
 
@@ -34,7 +34,7 @@ public class SettingsDb{
         }
 
         string rawText = System.IO.File.ReadAllText(SettingsPath);
-        settings = Util.FromJson<System.Collections.Generic.Dictionary<string, string>>(rawText);
+        settings = Util.FromJson<Dictionary<string, string>>(rawText);
     }
 
     public void InitSettings(){

--- a/src/Input/DeviceState.cs
+++ b/src/Input/DeviceState.cs
@@ -8,21 +8,21 @@ using System.Collections.Generic;
 public class DeviceState : Node {
 
   public int joypad; // Keyboard/Mouse input is the same for every DeviceState
-  private System.Collections.Generic.Dictionary<int, float> joyButtons;
-  private System.Collections.Generic.Dictionary<int, float> joyAxes;
+  private Dictionary<int, float> joyButtons;
+  private Dictionary<int, float> joyAxes;
 
 
-  private System.Collections.Generic.Dictionary<int, float> mouseButtons;
-  private System.Collections.Generic.Dictionary<int, float> keys;
+  private Dictionary<int, float> mouseButtons;
+  private Dictionary<int, float> keys;
   
   private Vector2 mousePosition, mouseMovement;
 
   public DeviceState(int joypad){
     this.joypad = joypad;
-    joyButtons = new System.Collections.Generic.Dictionary<int, float>();
-    joyAxes = new System.Collections.Generic.Dictionary<int, float>();
-    mouseButtons = new System.Collections.Generic.Dictionary<int, float>();
-    keys = new System.Collections.Generic.Dictionary<int, float>();
+    joyButtons = new Dictionary<int, float>();
+    joyAxes = new Dictionary<int, float>();
+    mouseButtons = new Dictionary<int, float>();
+    keys = new Dictionary<int, float>();
     mousePosition = new Vector2();
     mouseMovement = new Vector2();
   }
@@ -56,10 +56,10 @@ public class DeviceState : Node {
   }
 
   public void ClearInputs(){
-    joyButtons = new System.Collections.Generic.Dictionary<int, float>();
-    joyAxes = new System.Collections.Generic.Dictionary<int, float>();
-    mouseButtons = new System.Collections.Generic.Dictionary<int, float>();
-    keys = new System.Collections.Generic.Dictionary<int, float>();
+    joyButtons = new Dictionary<int, float>();
+    joyAxes = new Dictionary<int, float>();
+    mouseButtons = new Dictionary<int, float>();
+    keys = new Dictionary<int, float>();
   }
 
   // Will fail loudly if you listen for an invalid button/axis/key

--- a/src/Menus/CareerMenu.cs
+++ b/src/Menus/CareerMenu.cs
@@ -7,7 +7,7 @@ public class CareerMenu : Container, IMenu {
   public Button mainMenuButton;
   public Control careerParent;
   public List<CareerNode> careerNodes;
-  public System.Collections.Generic.Dictionary<int, Button> careerButtons;
+  public Dictionary<int, Button> careerButtons;
   public TextEdit background;
   public int targetOffset;
   public int minOffset;
@@ -78,7 +78,7 @@ public class CareerMenu : Container, IMenu {
     maxOffset = 0;
     targetOffset = minOffset;
 
-    careerButtons = new System.Collections.Generic.Dictionary<int, Button>();
+    careerButtons = new Dictionary<int, Button>();
 
     foreach(CareerNode node in careerNodes){
       AddNodeButton(node);

--- a/src/Menus/ShopMenu.cs
+++ b/src/Menus/ShopMenu.cs
@@ -6,7 +6,7 @@ public class ShopMenu : Container, IMenu {
   public Career career;
   public Button finishedButton;
   public List<Button> itemButtons;
-  public System.Collections.Generic.Dictionary<string, ItemData> itemsDict;
+  public Dictionary<string, ItemData> itemsDict;
 
 
   public void Init(){
@@ -25,7 +25,7 @@ public class ShopMenu : Container, IMenu {
 
     // itemButtons = new List<Button>();
     // List<ItemData> items = Career.ShopItems();
-    // itemsDict = new System.Collections.Generic.Dictionary<string, ItemData>();
+    // itemsDict = new Dictionary<string, ItemData>();
 
     // foreach(ItemData item in items){
     //   string shopName = item.extra["shop_name"];

--- a/src/Menus/UpgradeMenu.cs
+++ b/src/Menus/UpgradeMenu.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 
 public class UpgradeMenu : MenuBase {
-  public List<System.Collections.Generic.Dictionary<string, string>> cards;
+  public List<Dictionary<string, string>> cards;
   public TextEdit background;
   public List<Button> upgradeButtons;
   public const int CardsPerRow = 4;
@@ -23,9 +23,9 @@ public class UpgradeMenu : MenuBase {
     else{
       // IMPLEMENT ME
     }
-    cards = new List<System.Collections.Generic.Dictionary<string, string>>();
+    cards = new List<Dictionary<string, string>>();
     foreach(string cardName in cardNames){
-      System.Collections.Generic.Dictionary<string, string> card = CareerDb.GetCard(cardName);
+      Dictionary<string, string> card = CareerDb.GetCard(cardName);
       if(card != null){
         cards.Add(card);
       }
@@ -36,7 +36,7 @@ public class UpgradeMenu : MenuBase {
     background = Menu.BackgroundBox(this);
 
     upgradeButtons = new List<Button>();
-    foreach(System.Collections.Generic.Dictionary<string, string> card in cards){
+    foreach(Dictionary<string, string> card in cards){
       string upgradeName = card["name"] + "+"; 
       if(CareerDb.GetCard(upgradeName) == null){
         GD.Print("Card " + card["name"] + " has no upgrade.");

--- a/src/Stats/IcepawsStats.cs
+++ b/src/Stats/IcepawsStats.cs
@@ -5,18 +5,18 @@ using System.Collections.Generic;
   Base class for stats handlers that use ICEPAWS stats.
 */
 public class IcepawsStats : IStats, IReceiveDamage {
-  System.Collections.Generic.Dictionary<string, int> stats;
-  System.Collections.Generic.Dictionary<string, string> facts;
+  Dictionary<string, int> stats;
+  Dictionary<string, string> facts;
   private float updateTimer;
   private const float UpdateTime = 1f;
 
   public IcepawsStats(){
-    stats = new System.Collections.Generic.Dictionary<string, int>();
+    stats = new Dictionary<string, int>();
     foreach(string stat in GetStatList()){
       stats.Add(stat, 0);
     }
 
-    facts = new System.Collections.Generic.Dictionary<string, string>();
+    facts = new Dictionary<string, string>();
 
   }
 

--- a/src/Util/NetworkSession.cs
+++ b/src/Util/NetworkSession.cs
@@ -14,7 +14,7 @@ public class NetworkSession : Node {
   private const int MaxPlayers = 10;
   public const string DefaultServerAddress = "127.0.0.1";
   public int selfPeerId;
-  public System.Collections.Generic.Dictionary<int, PlayerData> playerData;
+  public Dictionary<int, PlayerData> playerData;
   public int randomSeed;
   public System.Random random;
   public int playersReady;
@@ -24,7 +24,7 @@ public class NetworkSession : Node {
   public string initName;
   
   public override void _Ready(){
-    playerData = new System.Collections.Generic.Dictionary<int, PlayerData>();
+    playerData = new Dictionary<int, PlayerData>();
   }
 
   public bool Initialized(){

--- a/src/Util/Session.cs
+++ b/src/Util/Session.cs
@@ -23,7 +23,7 @@ public class Session : Node {
   bool clearGame = false;
   public Node activeMenu;
   //public List<Node> activeGamemodes;
-  private System.Collections.Generic.Dictionary<string, Node> activeGamemodes;
+  private Dictionary<string, Node> activeGamemodes;
 
   public const string DebugMenu = "";
   public const bool DebugTests = false;
@@ -47,7 +47,7 @@ public class Session : Node {
 
   public override void _Ready() {
     PauseMode = PauseModeEnum.Process;
-    activeGamemodes = new System.Collections.Generic.Dictionary<string, Node>();
+    activeGamemodes = new Dictionary<string, Node>();
     EnforceSingleton();
     CareerDb.Init();
     ChangeMenu("MainMenu");

--- a/src/Util/Sound.cs
+++ b/src/Util/Sound.cs
@@ -45,18 +45,18 @@ public class Sound {
     Arena
   };
 
-  public static System.Collections.Generic.Dictionary<string, AudioStreamOGGVorbis> loadedMusic;
-  public static System.Collections.Generic.Dictionary<string, AudioStreamSample> loadedEffects;
+  public static Dictionary<string, AudioStreamOGGVorbis> loadedMusic;
+  public static Dictionary<string, AudioStreamSample> loadedEffects;
 
   public static void LoadSoundFiles(){
-    System.Collections.Generic.Dictionary<string, string> music = SoundDb.GetMusic();
-    loadedMusic = new System.Collections.Generic.Dictionary<string, AudioStreamOGGVorbis>();
+    Dictionary<string, string> music = SoundDb.GetMusic();
+    loadedMusic = new Dictionary<string, AudioStreamOGGVorbis>();
     foreach(string key in music.Keys){
       loadedMusic.Add(key, (AudioStreamOGGVorbis)GD.Load(music[key]));
     }
 
-    System.Collections.Generic.Dictionary<string, string> effects = SoundDb.GetEffects();
-    loadedEffects = new System.Collections.Generic.Dictionary<string, AudioStreamSample>();
+    Dictionary<string, string> effects = SoundDb.GetEffects();
+    loadedEffects = new Dictionary<string, AudioStreamSample>();
     foreach(string key in effects.Keys){
       loadedEffects.Add(key, (AudioStreamSample)GD.Load(effects[key]));
     }


### PR DESCRIPTION
Looks like Godot 3.1 magically resolved the class name collision of Godot's collections with the built-in ones.